### PR TITLE
画像プレビューに高さのレスポンシブ対応を追加

### DIFF
--- a/components/display-product-images/product-images.component.jsx
+++ b/components/display-product-images/product-images.component.jsx
@@ -21,7 +21,7 @@ const DisplayProductImages = ({ images }) => {
       <Image
         src={URL.createObjectURL(images[index])}
         width={smBreakPoint ? 250 : 160}
-        height={200}
+        height={smBreakPoint ? 200 : 130}
       />
       <ChevronRightButton />
     </ProductImagesContainer>


### PR DESCRIPTION
高さのレスポンシブ対応をしないと画面サイズが小さくなった時に、
横幅よりも高さが大きくなり、上の要素との間が開くようになってしまっていたので修正した。