### PR TITLE
GoogleFontsを導入し、react-dropzoneのフォントを変更

### DIFF
--- a/components/exhibit/exhibit.styles.jsx
+++ b/components/exhibit/exhibit.styles.jsx
@@ -15,5 +15,5 @@ export const DropzoneInput = styled.input`
   ${tw`h-full w-full`}
 `;
 export const DropzoneP = styled.p`
-  ${tw`h-1/2 w-full text-3xl sm:text-5xl font-bold text-red-800 font-abir`}
+  ${tw`h-1/2 w-full text-3xl sm:text-5xl font-bold text-red-800 font-bigelow`}
 `;

--- a/components/exhibit/exhibit.styles.jsx
+++ b/components/exhibit/exhibit.styles.jsx
@@ -15,5 +15,5 @@ export const DropzoneInput = styled.input`
   ${tw`h-full w-full`}
 `;
 export const DropzoneP = styled.p`
-  ${tw`h-1/2 w-full text-3xl sm:text-5xl font-bold text-red-800`}
+  ${tw`h-1/2 w-full text-3xl sm:text-5xl font-bold text-red-800 font-abir`}
 `;

--- a/components/my-link/my-link.styles.jsx
+++ b/components/my-link/my-link.styles.jsx
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 import tw from "tailwind.macro";
 
 const headerLeft = css`
-  ${tw`font-shoulders text-red-800`}
+  ${tw`text-red-800`}
 `;
 const headerRight = css`
   ${tw`text-yellow-600`}

--- a/components/my-link/my-link.styles.jsx
+++ b/components/my-link/my-link.styles.jsx
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 import tw from "tailwind.macro";
 
 const headerLeft = css`
-  ${tw`text-red-800`}
+  ${tw`font-shoulders text-red-800`}
 `;
 const headerRight = css`
   ${tw`text-yellow-600`}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,11 +12,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Big+Shoulders+Inline+Text:wght@500&family=Bigelow+Rules&family=Bowlby+One+SC&family=Open+Sans&family=Oswald&family=Raleway&family=Roboto&display=swap"
-            rel="stylesheet"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Big+Shoulders+Inline+Text:wght@500&family=Bigelow+Rules&family=Bowlby+One+SC&family=Open+Sans&family=Oswald&family=Raleway&family=Roboto&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Bigelow+Rules&display=swap"
             rel="stylesheet"
           />
         </Head>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,32 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Big+Shoulders+Inline+Text:wght@500&family=Bigelow+Rules&family=Bowlby+One+SC&family=Open+Sans&family=Oswald&family=Raleway&family=Roboto&display=swap"
+            rel="stylesheet"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Big+Shoulders+Inline+Text:wght@500&family=Bigelow+Rules&family=Bowlby+One+SC&family=Open+Sans&family=Oswald&family=Raleway&family=Roboto&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,9 @@ module.exports = {
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
-      fontFamily:{
-        abir: ['Abril Fatface', "cursive"],
-        shoulders: ['Open Sans', "sans-serif"]
-      }
+      fontFamily: {
+        bigelow: ["Bigelow Rules", "cursive"],
+      },
     },
   },
   variants: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,10 +2,15 @@ module.exports = {
   purge: [],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      fontFamily:{
+        abir: ['Abril Fatface', "cursive"],
+        shoulders: ['Open Sans', "sans-serif"]
+      }
+    },
   },
   variants: {
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
GoogleFontsを導入。

※わざわざtailwindcssにオリジナルのクラスを作成するよりも、
そのままCSSにfont-family: 'Bigshot One', cursive;のように
CSS rules to specify familiesを直接張り付けたほうがよさそう。
