### PR TITLE
react-dropzone部分を修正

### DIFF
--- a/components/exhibit/exhibit.pages.jsx
+++ b/components/exhibit/exhibit.pages.jsx
@@ -16,6 +16,10 @@ import ExhibitForm from "../exhibit-form/exhibit-form.component";
 
 const Exhibit = () => {
   const [images, setImages] = useState([]);
+  const accept = "image/*";
+  const onDrop = (acceptedFiles) => {
+    setImages(acceptedFiles.concat(images));
+  };
   const {
     getRootProps,
     getInputProps,
@@ -23,26 +27,9 @@ const Exhibit = () => {
     isDragAccept,
     isDragReject,
   } = useDropzone({
-    accept: "image/*",
-    getFilesFromEvent: (event) => handleDrop(event),
+    accept,
+    onDrop,
   });
-
-  //fileオブジェクトをstateに格納
-  const handleDrop = (event) => {
-    const files = [];
-    const fileList = event.dataTransfer
-      ? event.dataTransfer.files
-      : event.target.files;
-
-    for (let i = 0; i < fileList.length; i++) {
-      const file = fileList.item(i);
-      files.push(file);
-    }
-    if (files.length != 0) {
-      setImages(files.concat(images));
-    }
-    return files;
-  };
 
   //配列の何番目の画像を表示するか
   const [index, setIndex] = useState(0);
@@ -144,7 +131,15 @@ const Exhibit = () => {
       <ContainerDropzone
         {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
         <DropzoneInput {...getInputProps()} />
-        <DropzoneP>UPLOAD</DropzoneP>
+        {isDragActive ? (
+          isDragAccept ? (
+            <DropzoneP>UPLOAD</DropzoneP>
+          ) : (
+            <DropzoneP>REJECT</DropzoneP>
+          )
+        ) : (
+          <DropzoneP>Drag Files</DropzoneP>
+        )}
       </ContainerDropzone>
       {images.length != 0 && (
         <DisplayProductImages

--- a/components/exhibit/exhibit.styles.jsx
+++ b/components/exhibit/exhibit.styles.jsx
@@ -1,5 +1,22 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import tw from "tailwind.macro";
+
+const acceptSuccess = css`
+  ${tw`border-green-500 `}
+`;
+const acceptReject = css`
+  ${tw`border-red-500 `}
+`;
+
+const DropzoneActions = ({ isDragAccept, isDragActive }) => {
+  if (isDragActive) {
+    if (isDragAccept) {
+      return acceptSuccess;
+    } else {
+      return acceptReject;
+    }
+  }
+};
 
 export const ExhibitContainer = styled.div`
   ${tw`h-full w-full py-8 flex flex-col items-center bg-gray-500 overflow-auto`}
@@ -10,6 +27,8 @@ export const ContainerDropzone = styled.div`
   height: 20%;
   ${tw`w-1/2 h-1/5 border-8 border-indigo-600 border-dashed 
   text-center flex items-center justify-center`}
+
+  ${DropzoneActions}
 `;
 
 export const DropzoneInput = styled.input`
@@ -18,4 +37,3 @@ export const DropzoneInput = styled.input`
 export const DropzoneP = styled.p`
   ${tw`h-1/2 w-full text-5xl sm:text-7xl font-bold text-red-800 font-bigelow`}
 `;
-

--- a/components/my-link/my-link.styles.jsx
+++ b/components/my-link/my-link.styles.jsx
@@ -2,7 +2,8 @@ import styled, { css } from "styled-components";
 import tw from "tailwind.macro";
 
 const headerLeft = css`
-  ${tw`text-red-800`}
+  font-family: "Big Shoulders Stencil Text", cursive;
+  ${tw`text-red-800  text-2xl`}
 `;
 const headerRight = css`
   ${tw`text-yellow-600`}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,6 +15,10 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Bigelow+Rules&display=swap"
             rel="stylesheet"
           />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Stencil+Text&display=swap"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
react-dropzoneで画像をstateに格納する際、
getFilesFromEventを使っていたせいで、
acceptによる画像ファイル以外を弾く機能が無意味になってしまっていたので修正。

dropzoneの中に表示する文字を状況に合わせて変更するようにした。